### PR TITLE
load ggplot2 to fix error for 'plotDR()' function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: cytofWorkflow
 Title: CyTOF workflow: differential discovery in high-throughput
         high-dimensional cytometry datasets
-Version: 1.9.2
-Date: 2019-06-11
+Version: 1.9.3
+Date: 2019-08-23
 Authors@R: c(
 	person(role=c("aut", "cre"), "Malgorzata", "Nowicka", email = "gosia.nowicka.uzh@gmail.com"), 
 	person(role="aut", "Helena L.", "Crowell", email = "helena.crowell@uzh.ch"), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: cytofWorkflow
 Title: CyTOF workflow: differential discovery in high-throughput
         high-dimensional cytometry datasets
-Version: 1.9.3
-Date: 2019-08-23
+Version: 1.9.2
+Date: 2019-06-11
 Authors@R: c(
 	person(role=c("aut", "cre"), "Malgorzata", "Nowicka", email = "gosia.nowicka.uzh@gmail.com"), 
 	person(role="aut", "Helena L.", "Crowell", email = "helena.crowell@uzh.ch"), 

--- a/vignettes/cytofWorkflow.Rmd
+++ b/vignettes/cytofWorkflow.Rmd
@@ -82,6 +82,7 @@ options(width=75)
 suppressPackageStartupMessages({
     library(CATALYST)
     library(cowplot)
+    library(ggplot2)
     library(diffcyt)
     library(flowCore)
     library(readxl)


### PR DESCRIPTION
The Bioconductor build report (release version 3.9) is currently showing an error for the `plotDR()` function (lines 393-399) when adding a call to `theme()`:

```
p1 <- plotDR(daf, "TSNE", color_by = "meta20") + 
    theme(legend.position = "none")
```

When I load `ggplot2` manually before this, it works fine. I'm not sure if this is due to a change in `ggplot2` or `CATALYST`, but adding `library(ggplot2)` at the start of the workflow seems to solve the issue.